### PR TITLE
Correct nics-tools version to 6.3 to match other repos

### DIFF
--- a/image-processing/pom.xml
+++ b/image-processing/pom.xml
@@ -38,7 +38,7 @@
 	<parent>
 		<artifactId>master-pom</artifactId>
 		<groupId>edu.mit.ll.nics.tools</groupId>
-		<version>6.4-SNAPSHOT</version>
+		<version>6.3</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/openam-tools/pom.xml
+++ b/openam-tools/pom.xml
@@ -37,7 +37,7 @@
 	<parent>
         <artifactId>master-pom</artifactId>
         <groupId>edu.mit.ll.nics.tools</groupId>
-        <version>6.4-SNAPSHOT</version>
+        <version>6.3</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>edu.mit.ll.nics.tools</groupId>
 	<artifactId>master-pom</artifactId>
-	<version>6.4-SNAPSHOT</version>
+	<version>6.3</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/sso-tools/pom.xml
+++ b/sso-tools/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <artifactId>master-pom</artifactId>
         <groupId>edu.mit.ll.nics.tools</groupId>
-        <version>6.4-SNAPSHOT</version>
+        <version>6.3</version>
 		<relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/user-management-tools/pom.xml
+++ b/user-management-tools/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>edu.mit.ll.nics.tools</groupId>
 		<artifactId>master-pom</artifactId>
-		<version>6.4-SNAPSHOT</version>
+		<version>6.3</version>
 		<relativePath>..</relativePath>
 	</parent>
 


### PR DESCRIPTION
The 1stResponders repos do not currently build because the nics-tools repo version has been set forward to version 6.4-SNAPSHOT while all the other repos remain at version 6.3. This causes the nics-tools repo build to fail to resolve the nics-common dependencies.